### PR TITLE
Bean217/api

### DIFF
--- a/controllers/games.js
+++ b/controllers/games.js
@@ -8,6 +8,7 @@ const s3utils = require('../utils/s3utils');
 const gamesRouter = require('express').Router();
 const Game = require('../models/game');
 const mime = require('mime-types');
+const sql = require('yesql').pg;
 
 // utilities
 const multer = require('multer');
@@ -84,10 +85,25 @@ gamesRouter.post('/upload', upload.single('file'), async (req, res) => {
         }
         
         // if all of this succeeded, record game (title, s3 uuid, author name, game files hash value)        
-        const query = 
-            "INSERT INTO " + 
-            "game(game_id, author_username, upload_date, game_name, hash, description) " +
-            `VALUES ('${file.filename.split('.')[0]}', '${author}', NOW(), '${game_name}', '${gameFileHash.hash}', '${game_description}');`;
+        
+        // TODO: REMOVE OLD UNPARAMETERIZED QUERY
+        // const query = 
+        //     "INSERT INTO " + 
+        //     "game(game_id, author_username, upload_date, game_name, hash, description) " +
+        //     `VALUES ('${file.filename.split('.')[0]}', '${author}', NOW(), '${game_name}', '${gameFileHash.hash}', '${game_description}');`;
+
+
+        const query = sql("INSERT INTO " +
+                "game(game_id, author_username, upload_date, game_name, hash, description) " + 
+                "VALUES (:game_id, :author_username, NOW(), :game_name, :hash, :description);")
+                ({
+                    game_id: file.filename.split('.')[0],
+                    author_username: author,
+                    game_name: game_name,
+                    hash: gameFileHash.hash,
+                    description: game_description
+                })
+
         console.log(query);
 
         // Success, so create game record in the database
@@ -133,7 +149,7 @@ gamesRouter.post('/upload', upload.single('file'), async (req, res) => {
     const gameId = req.params.gameId;
 
     // check to make sure the game exists
-    let query = `SELECT COUNT(*) as num_games FROM game WHERE game_id = '${gameId}'`;
+    let query = sql("SELECT COUNT(*) as num_games FROM game WHERE game_id = :game_id")({game_id: gameId});
 
     var pool = undefined;
     try {
@@ -143,7 +159,7 @@ gamesRouter.post('/upload', upload.single('file'), async (req, res) => {
             return res.status(400).send(`game with id does not exist: ${gameId}`);
         } else {
             // Remove game from database
-            query = `DELETE FROM game WHERE game_id = '${gameId}'`
+            query = sql("DELETE FROM game WHERE game_id = :game_id")({game_id: gameId});
             await pool.query(query);
         }
         // delete game from s3

--- a/controllers/games.js
+++ b/controllers/games.js
@@ -85,14 +85,6 @@ gamesRouter.post('/upload', upload.single('file'), async (req, res) => {
         }
         
         // if all of this succeeded, record game (title, s3 uuid, author name, game files hash value)        
-        
-        // TODO: REMOVE OLD UNPARAMETERIZED QUERY
-        // const query = 
-        //     "INSERT INTO " + 
-        //     "game(game_id, author_username, upload_date, game_name, hash, description) " +
-        //     `VALUES ('${file.filename.split('.')[0]}', '${author}', NOW(), '${game_name}', '${gameFileHash.hash}', '${game_description}');`;
-
-
         const query = sql("INSERT INTO " +
                 "game(game_id, author_username, upload_date, game_name, hash, description) " + 
                 "VALUES (:game_id, :author_username, NOW(), :game_name, :hash, :description);")

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,8 @@
         "python-shell": "^3.0.1",
         "s3-list-all-objects": "^0.1.0",
         "underscore": "^1.13.6",
-        "uuid": "^9.0.0"
+        "uuid": "^9.0.0",
+        "yesql": "^5.0.0"
       },
       "devDependencies": {
         "nodemon": "^2.0.20"
@@ -4387,6 +4388,11 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
+    "node_modules/yesql": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yesql/-/yesql-5.0.0.tgz",
+      "integrity": "sha512-ua4Ok0hv6Q+KPn2oJrGNRfsubYnKPLJAt6kvawG6Aqb6yg4Cm1T2JIBveFNx0aDhCIansNVq/9MFzuvmNdnJnw=="
+    },
     "node_modules/zip-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.0.tgz",
@@ -7907,6 +7913,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "yesql": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yesql/-/yesql-5.0.0.tgz",
+      "integrity": "sha512-ua4Ok0hv6Q+KPn2oJrGNRfsubYnKPLJAt6kvawG6Aqb6yg4Cm1T2JIBveFNx0aDhCIansNVq/9MFzuvmNdnJnw=="
     },
     "zip-stream": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "python-shell": "^3.0.1",
     "s3-list-all-objects": "^0.1.0",
     "underscore": "^1.13.6",
-    "uuid": "^9.0.0"
+    "uuid": "^9.0.0",
+    "yesql": "^5.0.0"
   },
   "devDependencies": {
     "nodemon": "^2.0.20"


### PR DESCRIPTION
Fixed sql injection issues by using the npm yesql package for writing parameterized queries. Only queries with parameters need this. Any static string queries do not need to change or be put into the `sql("YOUR QUERY")({params});` format.